### PR TITLE
feat[back]: get permissions and roles using user id

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import modalityRouter from './routes/modalityRoutes';
 import adminRouter from './routes/adminRoutes';
 import statsRouter from './routes/statsRoutes';
 import emailRouter from './routes/emailRoutes';
+import permissionRouter from './routes/permissionRouters'
 
 dotenv.config();
 
@@ -30,5 +31,6 @@ app.use('/api/admin', adminRouter);
 app.use('/api/modality', modalityRouter);
 app.use('/api/stats', statsRouter);
 app.use('/api/email', emailRouter);
+app.use('/api/permission', permissionRouter);
 
 export default app;

--- a/src/controllers/permissionController.ts
+++ b/src/controllers/permissionController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import * as permissionInteractor from '../interactors/permissionsInteractor';
+import { handleError } from '../handlers/errorHandler';
+import { sendSuccess } from '../handlers/successHandler';
+
+export const getUserRolesAndPermissions = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const rolesAndPermissions = await permissionInteractor.getRolesAndPermissions(id);
+    sendSuccess(res, rolesAndPermissions, 'Roles and permissions retrieved successfully');
+  } catch (error) {
+    if (error instanceof Error) {
+      handleError(res, error);
+    }
+  }
+};

--- a/src/interactors/permissionsInteractor.ts
+++ b/src/interactors/permissionsInteractor.ts
@@ -1,0 +1,16 @@
+import * as userService from '../services/permissionService';
+import { NotFoundError } from '../errors/notFoundError';
+
+export const getRolesAndPermissions = async (userId: string) => {
+    try {
+      const rolesAndPermissions = await userService.getUserRolesAndPermissions(userId);
+  
+      if (!rolesAndPermissions|| Object.keys(rolesAndPermissions).length === 0) {
+        throw new NotFoundError('Permissions not found');
+      }
+      return rolesAndPermissions;
+    } catch (error) {
+      console.error('Error getting permissions:', error);
+      throw new Error('Error getting permissions');
+    }
+  };

--- a/src/models/permission.ts
+++ b/src/models/permission.ts
@@ -1,0 +1,7 @@
+interface Permission {
+    name:string;
+    id: number;
+  }
+  
+  export default Permission;
+  

--- a/src/repositories/permissionRepository.ts
+++ b/src/repositories/permissionRepository.ts
@@ -1,0 +1,26 @@
+import db from "./pg-connection";
+const tableName = 'users';
+
+export const getRoleAndPermissions = async (id: string) => {
+  try {
+    const rolesAndPermissionsRaw = await db(tableName)
+      .select('roles.name as role_name', 'permissions.name as permission_name')
+      .innerJoin('user_roles', 'users.id', 'user_roles.user_id')
+      .innerJoin('roles', 'user_roles.role_id', 'roles.id')
+      .innerJoin('role_permissions', 'roles.id', 'role_permissions.role_id')
+      .innerJoin('permissions', 'role_permissions.permission_id', 'permissions.id')
+      .where('users.id', id);
+    const rolesAndPermissions = rolesAndPermissionsRaw.reduce((acc, row) => {
+      const { role_name, permission_name } = row;
+      if (!acc[role_name]) {
+        acc[role_name] = [];
+      }
+      acc[role_name].push(permission_name);
+      return acc;
+    }, {});
+    return rolesAndPermissions;
+  } catch (error) {
+    console.error('Error in GenericRoleRepository.getRoleAndPermissions:', error);
+    throw new Error('Error fetching Roles and Permissions');
+  }
+}

--- a/src/routes/permissionRouters.ts
+++ b/src/routes/permissionRouters.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { checkUserAuth } from '../middlewares/checkUserAuth';
+import * as userController from '../controllers/permissionController';
+const router = Router();
+
+router
+    .route('/user/:id')
+    .get(checkUserAuth, userController.getUserRolesAndPermissions);
+
+export default router;

--- a/src/services/permissionService.ts
+++ b/src/services/permissionService.ts
@@ -1,0 +1,10 @@
+import Permission from "../models/permission";
+import * as permissionRepository from "../repositories/permissionRepository";
+
+export const getUserRolesAndPermissions = async (id: string):Promise<Permission | null> => {
+  const rolesAndPermissions = await permissionRepository.getRoleAndPermissions(id);
+  if (!rolesAndPermissions || Object.keys(rolesAndPermissions).length === 0) {
+    return null; 
+  }
+  return rolesAndPermissions;
+}


### PR DESCRIPTION
Se añadió la ruta, el controlador, interactor, service y repository de "Permissions" para poder obtener los permisos con sus respectivos roles segun el id de usario que le pase.
Para probar la ruta se coloca en postman:
http://localhost:3000/api/permission/user/(id usuario)