### PR TITLE
feat: Add delete user_profile and user_roles endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,8 @@ import modalityRouter from './routes/modalityRoutes';
 import adminRouter from './routes/adminRoutes';
 import statsRouter from './routes/statsRoutes';
 import emailRouter from './routes/emailRoutes';
-import permissionRouter from './routes/permissionRouters'
+import permissionRouter from './routes/permissionRouters';
+import userRouter from './routes/userRoutes';
 
 dotenv.config();
 
@@ -32,5 +33,5 @@ app.use('/api/modality', modalityRouter);
 app.use('/api/stats', statsRouter);
 app.use('/api/email', emailRouter);
 app.use('/api/permission', permissionRouter);
-
+app.use('/api/user', userRouter);
 export default app;

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+import * as userInteractor from '../interactors/userInteractor'
+import { sendSuccess } from '../handlers/successHandler';
+import { handleError } from '../handlers/errorHandler';
+
+export const deleteUser = async (req: Request, res: Response) => {
+  const userId = parseInt(req.params.id);
+
+  try {
+    await userInteractor.deleteUser(userId);
+    sendSuccess(res, null, 'User deleted successfully');
+  } catch (error) {
+    if (error instanceof Error) {
+      handleError(res, error);
+    }
+  }
+};

--- a/src/interactors/userInteractor.ts
+++ b/src/interactors/userInteractor.ts
@@ -1,0 +1,19 @@
+import * as UserService from '../services/userService';
+import * as UserRoleService from '../services/userRoleService';
+import { NotFoundError } from "../errors/notFoundError";
+
+export const deleteUser = async (userId: number) => {
+  try {
+    const user = await UserService.getUserById(userId);
+
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    await UserService.deleteUser(userId);
+    await UserRoleService.deleteUserRole(userId);
+  } catch (error) {
+    console.error('Error deleting student:', error);
+    throw new Error((error as Error).message);
+  }
+};

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -104,7 +104,7 @@ export const getProfessors = async () => {
 
 export const getUserById = async (userId: number) => {
   try {
-    const user = await db('users').where('id', userId).first();
+    const user = await db('user_profile').where('id', userId).first();
     return user;
   } catch (error) {
     console.error('Error fetching user by id:', error);
@@ -114,7 +114,7 @@ export const getUserById = async (userId: number) => {
 
 export const deleteUser = async (userId: number) => {
   try {
-    await db('users').where('id', userId).delete();
+    await db('user_profile').where('id', userId).delete();
   } catch (error) {
     console.error('Error deleting user:', error);
     throw error;

--- a/src/repositories/userRolesRepository.ts
+++ b/src/repositories/userRolesRepository.ts
@@ -13,3 +13,12 @@ export const assignUserRole = async (userId: number, userRoleId: number) => {
     throw new Error('Error assigning student role');
   }
 };
+
+export const deleteUserRole = async (userId: number) => {
+  try {
+    return await db(tableName).where('user_id', userId).delete();
+  } catch (error) {
+    console.error('Error deleting user role:', error);
+    throw error;
+  }
+};

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,21 +1,19 @@
 import { Router } from 'express';
-import * as AdminController from '../controllers/adminController';
+import UserRole from '../constants/roles';
 import * as userController from '../controllers/userController';
 import { checkUserAuth } from '../middlewares/checkUserAuth';
 import { requireRole } from '../middlewares/checkUserRole';
-import UserRole from '../constants/roles';
 import { validateBody } from '../middlewares/validateBodyMiddleware';
 import { createAdminSchema } from '../middlewares/schemas/createUserSchema';
 
 const router = Router();
 
 router
-  .route('/')
-  .post(
-    checkUserAuth,
-    requireRole([UserRole.ADMIN.name]),
-    validateBody(createAdminSchema),
-    AdminController.createAdmin
-  );
+    .route('/:id')
+    .delete(
+        checkUserAuth, 
+        // TODO: Make it work with requireRole
+        // requireRole([UserRole.ADMIN.name]),
+        userController.deleteUser)
 
 export default router;

--- a/src/services/userRoleService.ts
+++ b/src/services/userRoleService.ts
@@ -1,4 +1,7 @@
 import * as UserRolesRepository from '../repositories/userRolesRepository';
+import { buildLogger } from '../plugin/logger';
+
+const logger = buildLogger('userRoleService');
 
 export const createUserRole = async (userId: number, studentRole: number) => {
   try {
@@ -6,5 +9,16 @@ export const createUserRole = async (userId: number, studentRole: number) => {
   } catch (error) {
     console.log('Error creating User');
     throw Error('Error creating User');
+  }
+};
+
+export const deleteUserRole = async (userId: number) => {
+  try {
+    logger.debug(`Attempting to delete user role with user id: ${userId}`);
+    await UserRolesRepository.deleteUserRole(userId);
+    logger.info('User role deleted successfully.');
+  } catch (error) {
+    logger.error(`Error deleting user role: ${error}`);
+    throw new Error('Error deleting user role');
   }
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -59,3 +59,7 @@ export const deleteUser = async (userId: number) => {
     throw new Error('Error deleting user');
   }
 };
+
+export const getUserById = async (userId: number): Promise<User | null> => {
+  return UserRepository.getUserById(userId);
+};


### PR DESCRIPTION
Se añadió la ruta, el controlador, interactor, service y repository de "Users" para poder eliminar el user_profile y user_roles según una id de usuario que se la pase.
Para probar la ruta se coloca en postman:
http://localhost:3000/api/user/(id user)