### PR TITLE
feat[back]: added seed for permission_categories table

### DIFF
--- a/data/seeds/init_db.ts
+++ b/data/seeds/init_db.ts
@@ -2,10 +2,13 @@ import { Knex } from 'knex';
 // SOLO SE DEBE CORRER EN DEV o QA
 const rolesTable = 'roles';
 const userProfileTable = 'user_profile';
+const permissionCategoriesTable = 'permission_categories';
+
 exports.seed = async function (knex: Knex) {
   // Deletes ALL existing entries
   await knex(rolesTable).del();
   await knex(userProfileTable).del();
+  await knex(permissionCategoriesTable).del();
 
   await knex(rolesTable).insert([
     { id: 1, name: 'admin' },
@@ -26,6 +29,13 @@ exports.seed = async function (knex: Knex) {
       role_id: 1,
     },
   ]);
+  await knex(permissionCategoriesTable).insert([
+    { id: 1, name: 'Reportes'},
+    { id: 2, name: 'Proceso de graduación'},
+    { id: 3, name: 'Docentes'},
+    { id: 4, name: 'Estudiantes'},
+    { id: 5, name: 'Usuarios'},
+  ])
 
   // return knex('stages')
   //   .del()


### PR DESCRIPTION
Se creó el Seed para la tabla permission_categories.

Para ver todos los cambios es necesario levantar Docker y luego npm run seed:run