### PR TITLE
fix[back]:added a new scheme to edit a role name

### DIFF
--- a/src/middlewares/schemas/EditRoleNameScheme.ts
+++ b/src/middlewares/schemas/EditRoleNameScheme.ts
@@ -1,0 +1,8 @@
+import Joi from 'joi';
+
+export const roleNameScheme = Joi.object({
+  name: Joi.string().required().messages({
+    'any.required': 'Name is required.',
+  }),
+});
+

--- a/src/routes/rolesRoutes.ts
+++ b/src/routes/rolesRoutes.ts
@@ -5,6 +5,7 @@ import { validateBody } from '../middlewares/validateBodyMiddleware';
 import RolesByNameSchema from '../middlewares/schemas/searchRolesByNameSchema';
 import baseRolSchema from '../middlewares/schemas/BaseRolSchema';
 import rolePermissionsSchema from '../middlewares/schemas/rolePermissionSchema';
+import { roleNameScheme } from '../middlewares/schemas/EditRoleNameScheme';
 const router = Router();
 
 router
@@ -15,7 +16,7 @@ router
   .delete(checkUserAuth, validateBody(rolePermissionsSchema), RolesController.removePermission);
 router.route('/').get(checkUserAuth, validateBody(RolesByNameSchema), RolesController.getRoles);
 router.route('/').post(checkUserAuth, validateBody(baseRolSchema), RolesController.createRol);
-router.route('/:id').put(checkUserAuth, validateBody(baseRolSchema), RolesController.editRol);
+router.route('/:id').put(checkUserAuth, validateBody(roleNameScheme), RolesController.editRol);
 router.route('/:id').delete(checkUserAuth, RolesController.disableRol);
 router.route('/student').get(checkUserAuth, RolesController.getRolesStudent);
 router.route('/professor').get(checkUserAuth, RolesController.getRolesProfessor);


### PR DESCRIPTION
Se añadió una nueva scheme para editar el nombre de un rol:
para probar es el siguiente link: 
PUT
http://localhost:3000/api/roles/(idRole)

Body de ejemplo:
{
    "name": "New name changed test"
}